### PR TITLE
Partially Automate CBO Baseline Updates

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,3 +11,5 @@ dependencies:
 - pytest
 - pulp
 - tqdm
+- requests
+- lxml

--- a/puf_stage1/doc/CBO_Baseline_Updating_Instructions.md
+++ b/puf_stage1/doc/CBO_Baseline_Updating_Instructions.md
@@ -12,6 +12,23 @@ The year of the file/report the current numbers come from as well as the year
 of the file/report used before the most recent update are listed for each
 variable. These will needed to be updated with each update of `CBO_baseline.csv`.
 
+Almost all of the updates to `CBO_baseline.csv` can be done by updating and
+running `puf_stage1.py/updatecbo.py`. Instructions for how to update the file
+can be found in the following sections:
+
+1. [Variables in 10-Year CBO Projections](#Variables-in-10-Year-CBO-Projections)
+2. [CGNS](#CGNS)
+3. [CPIM (CPI Medical Care)](#CPIM-(CPI-Medical-Care))
+
+The code in `puf_stage1.py/updatecbo.py` assumes that the format of the
+spreadsheets provided by the CBO and the API provided by the BLS remain
+unchanged. If the program throws an error or the results do not look correct,
+it is likely that one of those assumptions is no longer true.
+
+The only variables in `CBO_baseline.csv` that cannot be updated automatically
+are `RETS`, `SOCSEC`, and `UCOMP`. Instructions for updating those manually
+can be found below.
+
 If the updates include projections for years that were not there previously,
 `puf_stage1/stage1.py`, `cps_stage1/stage1.py`, `puf_stage2/stage2.py`, and
 `cps_stage2/stage2.py` will also need to be updated. Instructions for doing so
@@ -28,10 +45,10 @@ appears in the new file/report used.
 
 As previously mentioned, most of the variables we used can be found in the
 [CBO 10-Year Economics Projections](https://www.cbo.gov/about/products/budget-economic-data#4).
-These are the easiest to update because all you need to do is copy and paste
-the values from the calendar year CBO projections into the CBO baseline spreadsheet.
-To avoid any potential formatting conflicts, be sure to select `Paste Values`
-in Excel.
+To update these variables, replace the URL assigned to the `econ_url` variable
+in `puf_stage1/updatecbo.py` with the link to the latest CBO economic projections
+and run the file. Or you could download the file and copy/paste the specific
+variables.
 
 Previous Document: August 2016
 
@@ -62,6 +79,11 @@ Current: April 2018
 
 Notes: In the revenue projections file, the data is in the `Capital Gains Realizations`
 tab under the `Capital Gains Realizations` column.
+
+To update this variables, replace the URL assigned to the `cg_url` variable in
+`puf_stage1/updatecbo.py` with the link to the most recent CBO revenue
+projections and run the file. Or download the spreadsheet and manually update
+the projections.
 
 ### RETS
 
@@ -100,9 +122,12 @@ Instructions:
 2. Under "Select view of the data," select "Original Data Value"
 3. Click "Retrieve Data"
 4. Download the table at the bottom of the page
-5. Take the 12 mont average for each year in the data
+5. Take the 12 month average for each year in the data
 6. Find the average difference between CPI-U from the CBO 10-Year projections
 7. Add this average difference to the CBO CPI-U projections
+
+OR: Simply run `puf_stage1/updatecbo.py`, which will use the BLS provided API
+to pull the latest data.
 
 ### UCOMP
 

--- a/puf_stage1/updatecbo.py
+++ b/puf_stage1/updatecbo.py
@@ -1,0 +1,133 @@
+import os
+import requests
+import pandas as pd
+
+
+CUR_PATH = os.path.abspath(os.path.dirname(__file__))
+
+
+def update_cpim(baseline):
+    """
+    Update the CPI-M values in the CBO baseline using the BLS API
+    """
+    print("Updating CPI-M Values")
+    url = 'https://api.bls.gov/publicAPI/v1/timeseries/data/CUSR0000SAM'
+    # fetch BLS data from about url
+    r = requests.get(url)
+    # raise and error if the request fails
+    assert r.status_code == 200
+    result_json = r.json()
+    # raise error if request was not successful
+    assert result_json['status'] == 'REQUEST_SUCCEEDED'
+    # extract the data from the results
+    data = result_json['Results']['series'][0]['data']
+    df = pd.DataFrame(data)
+    # convert the values to floats so that the groupby mean only returns
+    # the mean for the value
+    df['value'] = df['value'].astype(float)
+    cpi_mean = df.groupby('year').mean().transpose().round(1)
+    cpi_mean.index = ["CPIM"]
+
+    # open the current baseline to replace the values for the years pulled
+    # from BLS
+    baseline.update(cpi_mean)
+
+    # find the average difference between CPIM and CPIU for available years
+    last_year = max(cpi_mean.columns)
+    first_year = min(baseline.columns)
+    # retrieve subset of the DataFrame containing actual CPIM values
+    split_col = int(last_year) - int(first_year) + 1
+    sub_baseline = baseline[baseline.columns[: split_col]]
+
+    # find the difference
+    mean_diff = (sub_baseline.loc['CPIM'] - sub_baseline.loc['CPIU']).mean()
+
+    # update the future values to reflect the difference between
+    new_vals = {}
+    for col in baseline.columns[split_col:]:
+        cpiu = baseline[col].loc['CPIU']
+        new_val = cpiu + mean_diff
+        new_vals[col] = [new_val]
+    future_df = pd.DataFrame(new_vals, index=["CPIM"]).round(1)
+    baseline.update(future_df)
+
+    return baseline
+
+
+def update_econproj(econ_url, cg_url, baseline):
+    """
+    Function that will read new CBO economic projections and update
+    CBO_baseline.csv accordingly
+    """
+    print("Updating CBO Economic Proections")
+    # read in economic projections
+    econ_proj = pd.read_excel(econ_url, sheet_name="2. Calendar Year",
+                              skiprows=5, index_col=[0, 1, 2, 3])
+    # extract values for needed rows in the excel file
+    # some variables have a missing value in the multi-index. Use iloc
+    # to extract needed variables from them.
+    gdp = econ_proj.loc["Output"].loc["Gross Domestic Product (GDP)"].iloc[0]
+    income = econ_proj.loc["Income"]
+    tpy = income.loc["Income, Personal"].iloc[0]
+    wages = income.loc["Wages and Salaries"].iloc[0]
+    billions = "Billions of dollars"
+    var = "Proprietors' income, nonfarm, with IVA & CCAdj"
+    schc = income.loc["Nonwage Income"].loc[var].loc[billions]
+    var = "Proprietors' income, farm, with IVA & CCAdj"
+    schf = income.loc["Nonwage Income"].loc[var].loc[billions]
+    var = "Interest income, personal"
+    ints = income.loc["Nonwage Income"].loc[var].loc[billions]
+    var = "Dividend income, personal"
+    divs = income.loc["Nonwage Income"].loc[var].loc[billions]
+    var = "Income, rental, with CCAdj"
+    rents = income.loc["Nonwage Income"].loc[var].loc[billions]
+    book = income.loc["Profits, Corporate, With IVA & CCAdj"].iloc[0]
+    var = "Consumer Price Index, All Urban Consumers (CPI-U)"
+    cpiu = econ_proj.loc["Prices"].loc[var].iloc[0]
+
+    # Extract capital gains data
+    cg_proj = pd.read_excel(cg_url, sheet_name="6. Capital Gains Realizations",
+                            skiprows=7, header=[0, 1])
+    var = "Capital Gains Realizationsa"
+    cgns = cg_proj[var][billions].loc[econ_proj.columns]
+
+    # create one DataFrame from all of the data
+
+    var_list = [gdp, tpy, wages, schc, schf, ints, divs, rents, book, cpiu,
+                cgns]
+    var_names = ["GDP", "TPY", "Wages", "SCHC", "SCHF", "INTS", "DIVS",
+                 "RENTS", "BOOK", "CPIU", "CGNS"]
+    df = pd.DataFrame(var_list, index=var_names).round(1)
+    df.columns = df.columns.astype(str)
+
+    # update baseline file with the new data
+
+    # add a column for any years that are in the update but not yet in the
+    # CBO baseline file before updating the values
+    df_cols = set(df.columns)
+    baseline_cols = set(baseline.columns)
+    for col in df_cols - baseline_cols:
+        baseline[col] = None
+    baseline.update(df)
+
+    return baseline
+
+
+def update_cbo():
+    econ_url = "https://www.cbo.gov/system/files/2019-01/51135-2019-01-economicprojections.xlsx"
+    cg_url = "https://www.cbo.gov/system/files/2019-02/51138-2019-01-revenueprojections.xlsx"
+    baseline = pd.read_csv(os.path.join(CUR_PATH, "CBO_baseline.csv"),
+                           index_col=0)
+    baseline = update_econproj(econ_url, cg_url, baseline)
+    baseline = update_cpim(baseline)
+
+    return baseline
+
+
+if __name__ == "__main__":
+    baseline = update_cbo()
+    baseline.to_csv(os.path.join(CUR_PATH, "CBO_baseline.csv"))
+    msg = ("NOTE: This program does not update every variable in the baseline."
+           " Remember to update RETS, SOCSEC, and UCOMP by following the "
+           "instructions found in CBO_Baseline_Updating_Instructions.md")
+    print(msg)


### PR DESCRIPTION
This PR adds a new script `puf_stage1/updatecbo.py` that automates parts of the `CBO_baseline.csv` updating process. It can pull all of the needed data from the CBO 10-year economic projections file, the CBO revenue projections, and uses the BLS API to update CPI-M. I say it's a partial automation because three variables cannot be easily automated: `RETS`, `SOCSEC`, and `UCOMP` all either come from a PDF or a website that cannot be reliably scraped. The documentation has been updated to reflect this and the new script will print out a message after it has finished reminding the user to update those manually. Additionally, the file needs to be updated to point to the new CBO files each time there's a new release.

Though there is still a non-trivial amount of work that needs to be done to update `CBO_baseline.csv`, this file handles a large chunk of tasks associated with the updates and significantly reduces the likelihood of user error in the updating process.

I did not add this script to the make file process because of all the manual work that needs to accompany its use.