### PR TITLE
Change soi_rets.py docstring

### DIFF
--- a/puf_data/StatMatch/Matching/soi_rets.py
+++ b/puf_data/StatMatch/Matching/soi_rets.py
@@ -1,7 +1,7 @@
 """
 Create a composite extract from the SOI 2009 Public Use File
-Input file: puf2009.sas7bdat
-Output file: SOIRETS2009.csv
+Input file: puf20011.csv
+Output file: None
 """
 # import pandas as pd
 import numpy as np


### PR DESCRIPTION
This PR updates the docstring at the top of `soi_rets.py` to reflect that we are now using the 2011 PUF and no longer creating an output file. Thanks to @donboyd5 for pointing this out in issue #327.