### PR TITLE
Sort PUF columns

### DIFF
--- a/taxdata/puf/finalprep.py
+++ b/taxdata/puf/finalprep.py
@@ -74,6 +74,9 @@ def finalprep(data):
     # - Rename 'filer' to 'data_source'
     data = data.rename(columns={"filer": "data_source"})
 
+    # - Sort columns to ensure every PUF is the same
+    data.sort_index(axis=1, inplace=True)
+
     return data
 
 


### PR DESCRIPTION
This PR resolves issue #433. It simply sorts the PUF columns before they're exported after final prep. Using `createpuf.py` I was able to create two PUFs with identical MD5s.

cc @jdebacker @bodiyang 